### PR TITLE
Typeahead fixes and enhancements

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -33,6 +33,7 @@
     "paper-item": "PolymerElements/paper-item#^1.0.5"
   },
   "devDependencies": {
+    "paper-toggle-button": "PolymerElements/paper-toggle-button#^1.0.11",
     "webcomponentsjs": "webcomponents/webcomponentsjs#^0.7.0",
     "web-component-tester": "Polymer/web-component-tester#^3.3.0",
     "test-fixture": "PolymerElements/test-fixture#^1.0.0"

--- a/demo/index.html
+++ b/demo/index.html
@@ -6,12 +6,18 @@
   <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1, user-scalable=yes">
   <title>radium-combo demo</title>
   <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
+  <link rel="import" href="../../paper-toggle-button/paper-toggle-button.html">
   <link rel="import" href="../radium-combo.html">
   <style>body { font-family: "Roboto", "Helvetica Neue", Helvetica, Arial, sans-serif; }</style>
   <style is="custom-style">
     #demo-container {
       padding: 0px 2% !important;
       height: 100%;
+    }
+    #config-container {
+      padding: 16px 2% !important;
+      background-color: #efefef;
+      margin-top: 48px
     }
     .example-title {
       margin-top: 32px;
@@ -31,7 +37,7 @@
       font-weight: bold;
       font-size: 14px;
       display: inline-block;
-      margin-top: 48px;
+      margin-top: 24px;
     }
     .event-string {
       font-style: italic;
@@ -50,33 +56,38 @@
       <div class="example-col">
         <div class="example-title">Select w/ empty option label</div>
         <div class="example-selected">Selected - <span>[[_selected1.label]]</span></div>
-        <radium-combo options="[[_myoptions]]" value="{{_selected1}}" empty-option-label="--unselect--"
-            on-option-change="_optionSelected"></radium-combo>
+        <radium-combo options="[[_myoptions]]" value="{{_selected1}}" show-clear-button="[[_showClearButton]]"
+            empty-option-label="--unselect--" on-option-change="_optionSelected"></radium-combo>
         <div class="example-title">Select w/ initial value</div>
         <div class="example-selected">Selected - <span>[[_selected2.label]]</span></div>
-        <radium-combo options="[[_myoptions]]" value="{{_selected2}}"
+        <radium-combo options="[[_myoptions]]" value="{{_selected2}}" show-clear-button="[[_showClearButton]]"
             on-option-change="_optionSelected"></radium-combo>
         <div class="example-title">Select w/ no empty value (force selection)</div>
         <div class="example-selected">Selected - <span>[[_selected3.label]]</span></div>
-        <radium-combo options="[[_myoptions]]" include-empty="false" value="{{_selected3}}"
+        <radium-combo options="[[_myoptions]]" include-empty="false" value="{{_selected3}}" show-clear-button="[[_showClearButton]]"
             on-option-change="_optionSelected"></radium-combo>
       </div>
       <div class="example-col" style="margin-left: 3%">
         <div class="example-title">Disabled</div>
         <div class="example-selected">Selected - <span>[[_selected4.label]]</span></div>
-        <radium-combo options="[[_myoptions]]" disabled value="{{_selected4}}"
+        <radium-combo options="[[_myoptions]]" disabled value="{{_selected4}}" show-clear-button="[[_showClearButton]]"
             on-option-change="_optionSelected"></radium-combo>
         <div class="example-title">Typeahead</div>
         <div class="example-selected">Selected - <span>[[_selected5.label]]</span></div>
-        <radium-combo options="[[_myoptions]]" type="typeahead" value="{{_selected5}}"
+        <radium-combo options="[[_myoptions]]" type="typeahead" value="{{_selected5}}" show-clear-button="[[_showClearButton]]"
             on-option-change="_optionSelected"></radium-combo>
         <div class="example-title">Combobox</div>
         <div class="example-selected">Selected - <span>[[_selected6.label]]</span></div>
-        <radium-combo options="[[_myoptions]]" type="combobox" value="{{_selected6}}"
+        <radium-combo options="[[_myoptions]]" type="combobox" value="{{_selected6}}" show-clear-button="[[_showClearButton]]"
             on-option-change="_optionSelected"></radium-combo>
       </div>
     </div><br>
-    <div class="event-label">Option Change Event:</div><div class="event-string">[[_lastEvent]]</div>
+    <div id="config-container">
+      <div>
+        <paper-toggle-button active="{{_showClearButton}}">Show Clear Button</paper-toggle-button>
+      </div>
+      <div class="event-label">Option Change Event:</div><div class="event-string">[[_lastEvent]]</div>
+    </div>
   </template>
   <script>
     app._myoptions = [{label:'Joe', value:'1'}

--- a/radium-combo.html
+++ b/radium-combo.html
@@ -415,7 +415,7 @@ Material Design Dropdown/Typeahead/Combobox control
         this.setValue(item.value, true);
       },
       _updateAndDispatch: function(value, dispatch) {
-        if (this.value.value !== value.__value) {
+        if (this.value.__label !== value.__label && this.value.__value !== value.__value) {
           this.value = value;
           if (dispatch === true) {
             this.fire('option-change', {label:value.__label, value:value.__value});

--- a/radium-combo.html
+++ b/radium-combo.html
@@ -353,6 +353,7 @@ Material Design Dropdown/Typeahead/Combobox control
         }
         if (node === null) {
           this.async(function() {
+            this._applyValueFromInput();
             this._hideDropdown();
           }, 10);
         }
@@ -471,7 +472,10 @@ Material Design Dropdown/Typeahead/Combobox control
         }
 
         this.$.selector.selected = idx;
-        this.value = this._filteredOptions[(this._showEmpty === true) ? idx - 1 : idx];
+
+        var option = this._filteredOptions[(this._showEmpty === true) ? idx - 1 : idx];
+        this.$.input.value = (option) ? option.__label : '';
+
         var itemHeight = 49;
         var numVisible = Math.floor(this.$.selector.parentNode.offsetHeight / itemHeight);
         if (isUp) {

--- a/radium-combo.html
+++ b/radium-combo.html
@@ -69,12 +69,12 @@ Material Design Dropdown/Typeahead/Combobox control
       <div class="dropdown-content">
         <iron-selector id="selector" attrForSelected="value">
           <template is="dom-if" if="[[_checkShowEmpty(_showEmpty, type)]]">
-            <paper-item on-click="_hideDropdown" value="">
+            <paper-item on-down="_selectItem" on-click="_hideDropdown" value="">
               <span>[[emptyOptionLabel]]</span>
             </paper-item>
           </template>
           <template is="dom-repeat" items="[[_filteredOptions]]">
-            <paper-item on-click="_hideDropdown" value="[[item.__value]]">
+            <paper-item on-down="_selectItem" on-click="_hideDropdown" value="[[item.__value]]">
               <span>[[item.__label]]</span>
             </paper-item>
           </template>
@@ -191,7 +191,7 @@ Material Design Dropdown/Typeahead/Combobox control
         },
         _open: {
           type: Boolean,
-          default: false
+          value: false
         },
         _boundOnCaptureClick: {
           type: Function,
@@ -200,26 +200,23 @@ Material Design Dropdown/Typeahead/Combobox control
           }
         }
       },
-      listeners: {
-        'tap': '_updateSelected'
-      },
       observers: [
         '_optionsSplicesChanged(options.splices)'
       ],
       _boundResizeHandler: null,
-      _valueChanged: function(v, old) {
-        var normalized;
-        if (this._isObject(v)) {
-          normalized = v;
-        } else {
+      _valueChanged: function(v) {
+        if (!this._isObject(v)) {
           var vm = this._findValueMatch(v);
-          if (vm === null) {
-            this._setInputValue('');
-            return;
+          if (vm !== null) {
+            this.value = vm.match;
           }
-          this.value = vm.match;
         }
-        this._setInputValue(this.value.__label);
+        if (this.value) {
+          this._setInputValue(this.value.__label || '');
+        }
+        else {
+          this._setInputValue('');
+        }
       },
       _typeChanged: function(v) {
         if (v) {
@@ -313,16 +310,19 @@ Material Design Dropdown/Typeahead/Combobox control
           }, 10);
         }
       },
-      _openDropdown : function() {
+      _openDropdown: function() {
         if (this._open === false) {
           this._open = true;
           document.addEventListener('click', this._boundOnCaptureClick, true);
           this.$.dropdown.style.width = this.$['input-container'].offsetWidth + 'px';
           this.$.dropdown.positionTarget = this;
           this.$.dropdown.open();
+          this._filterOptions('');
+          // Select the dropdown item based on the current value.
+          this._setSelectorSelected(this._findFilteredOptionValueIndex(this.value.__value));
         }
       },
-      _hideDropdown : function() {
+      _hideDropdown: function() {
         if (this._open === true) {
           this._open = false;
           document.removeEventListener('click', this._boundOnCaptureClick, true);
@@ -339,6 +339,8 @@ Material Design Dropdown/Typeahead/Combobox control
         var input = e.target.value;
         this._handleFloatingLabel(input);
         this._filterOptions(input);
+        // Select the dropdown item based on the current input.
+        this._setSelectorSelected(this._findFilteredOptionLabelIndex(input));
         this._openDropdown();
       },
       _applyValueFromInput: function() {
@@ -347,47 +349,23 @@ Material Design Dropdown/Typeahead/Combobox control
       _filterOptions: function(input) {
         if (!input || input === null || input === '') {
           this._filteredOptions = this._optionsInternal;
-          return;
         }
-        var newArr = [];
-        for (var i = 0; i < this._optionsInternal.length; i++) {
-          var opt = this._optionsInternal[i];
-          if (opt.__label.toLowerCase().indexOf(input.toLowerCase()) === 0) {
-            newArr.push(opt);
-          }
+        else {
+          this._filteredOptions = this._optionsInternal.filter(function(option) {
+            return option.__label.toLowerCase().indexOf(input.toLowerCase()) === 0;
+          });
         }
-        this._filteredOptions = newArr;
       },
-      _updateSelected: function(e) {
-        if (e && (e.target.nodeName.toLowerCase() === 'paper-item' ||
-            e.target.parentNode.nodeName.toLowerCase() === 'paper-item')) {
-          var selIdx = this.$.selector.selected;
-          if (selIdx !== undefined) {
-            if (this._showEmpty === false) {
-              this._updateAndDispatch(this._filteredOptions[selIdx], true);
-            } else {
-              if (selIdx === 0) {
-                this._updateAndDispatch('', true);
-              } else {
-                this._updateAndDispatch(this._filteredOptions[selIdx - 1], true);
-              }
-            }
-          }
-        }
+      _selectItem: function(e) {
+        var item = e.currentTarget;
+        this.setValue(item.value, true);
       },
       _updateAndDispatch: function(value, dispatch) {
-        this.value = value;
-        if (typeof dispatch !== 'undefined' && dispatch === true) {
-          this.fire('option-change', {label:value.__label, value:value.__value});
-        }
-      },
-      _applyInitialValue: function() {
-        if (this.value && this.value !== '') {
-          var idx = this._optionsInternal.indexOf(this.value);
-          if (this._showEmpty === true) {
-            idx = idx + 1;
+        if (this.value !== value) {
+          this.value = value;
+          if (dispatch === true) {
+            this.fire('option-change', {label:value.__label, value:value.__value});
           }
-          this.$.selector.select(idx);
         }
       },
       _onInputBlur: function() {
@@ -450,12 +428,24 @@ Material Design Dropdown/Typeahead/Combobox control
           this.$.selector.parentNode.scrollTop = (idx >= numVisible) ? idx * itemHeight : 0;
         }
       },
-      _findValueMatch: function(v) {
-        if ((v === null) || (v === undefined))
-        {
+      _findLabelMatch: function(lbl) {
+        if ((lbl === null) || (lbl === undefined)) {
           return null;
         }
-
+        if (this._optionsInternal) {
+          for (var idx = 0; idx < this._optionsInternal.length; idx++ ) {
+            var opt = this._optionsInternal[idx];
+            if ( opt && opt.__label.toLowerCase() === lbl.toLowerCase() ) {
+              return {match:opt, index:idx};
+            }
+          }
+        }
+        return null;
+      },
+      _findValueMatch: function(v) {
+        if ((v === null) || (v === undefined)) {
+          return null;
+        }
         if (this._optionsInternal) {
           for (var idx = 0; idx < this._optionsInternal.length; idx++) {
             var opt = this._optionsInternal[idx];
@@ -466,6 +456,34 @@ Material Design Dropdown/Typeahead/Combobox control
         }
         return null;
       },
+      _findFilteredOptionLabelIndex: function(lbl) {
+        if ((lbl === null) || (lbl === undefined)) {
+          return -1;
+        }
+        if (this._filteredOptions) {
+          for (var idx = 0; idx < this._filteredOptions.length; idx++) {
+            var opt = this._filteredOptions[idx];
+            if (opt && opt.__label.toString() === lbl.toString()) {
+              return idx;
+            }
+          }
+        }
+        return -1;
+      },
+      _findFilteredOptionValueIndex: function(v) {
+        if ((v === null) || (v === undefined)) {
+          return -1;
+        }
+        if (this._filteredOptions) {
+          for (var idx = 0; idx < this._filteredOptions.length; idx++) {
+            var opt = this._filteredOptions[idx];
+            if (opt && opt.__value.toString() === v.toString()) {
+              return idx;
+            }
+          }
+        }
+        return -1;
+      },
       _isObject: function(val) {
         if (val === null) { return false;}
         return ( (typeof val === 'function') || (typeof val === 'object') );
@@ -474,32 +492,40 @@ Material Design Dropdown/Typeahead/Combobox control
         this._handleFloatingLabel(v);
         this.$.input.value = v;
       },
+      _setSelectorSelected: function(idx) {
+        if (this._showEmpty === true && idx >= 0) {
+          this.$.selector.selected = idx + 1;
+        }
+        else {
+          this.$.selector.selected = idx;
+        }
+      },
+      _setValue(lbl, match, dispatch) {
+        if (match !== null) {
+          this._setInputValue(match.match.__label || '');
+          this._updateAndDispatch(match.match, dispatch);
+        }
+        else {
+          if (this.type.toLowerCase() === 'combobox' && lbl) {
+            this._setInputValue(lbl);
+            this._updateAndDispatch({__label: lbl, __value: undefined}, dispatch);
+          }
+          else {
+            this._setInputValue('');
+            this._updateAndDispatch({}, dispatch);
+          }
+        }
+        this._hideDropdown();
+      },
       /**
        * Use the provided label to select an item
        *
        * @param {String} lbl The value to make selected
-       * @param {Boolean} dispatch Whether or not to send a change event when deselecting
+       * @param {Boolean} dispatch Whether or not to send a change event when selecting
        */
       setValueFromLabel: function(lbl, dispatch) {
-        var match = null;
-        var idx = 0;
-        for (idx; idx < this._optionsInternal.length; idx++) {
-          var opt = this._optionsInternal[idx];
-          if (opt && opt.__label.toLowerCase() === lbl.toLowerCase()) {
-            match = opt;
-            break;
-          }
-        }
-        if (match !== null) {
-          this._updateAndDispatch(match, dispatch);
-          this.$.selector.select(idx);
-        } else if (this.type.toLowerCase() === 'combobox') {
-          this._updateAndDispatch({__label:lbl,__value:undefined}, dispatch);
-          this.$.selector.select(-1);
-        } else {
-          this.clearSelection(dispatch);
-        }
-        this._hideDropdown();
+        var match = this._findLabelMatch(lbl);
+        this._setValue(lbl, match, dispatch);
       },
       /**
        * Use the provided value to select an item
@@ -508,17 +534,8 @@ Material Design Dropdown/Typeahead/Combobox control
        * @param {Boolean} dispatch Whether or not to send a change event when selecting
        */
       setValue: function(v, dispatch) {
-        var vm = this._findValueMatch(v);
-        if (vm !== null) {
-          this._updateAndDispatch(vm.match, dispatch);
-          this.$.selector.select(vm.index);
-        } else if (this.type.toLowerCase() === 'combobox') {
-          this._updateAndDispatch({__label:v,__value:undefined}, dispatch);
-          this.$.selector.select(-1);
-        } else {
-          this.clearSelection(dispatch);
-        }
-        this._hideDropdown();
+        var match = this._findValueMatch(v);
+        this._setValue(v, match, dispatch);
       },
       /**
        * Clear the current selection
@@ -526,9 +543,7 @@ Material Design Dropdown/Typeahead/Combobox control
        * @param {Boolean} dispatch Whether or not to send a change event when deselecting
        */
       clearSelection: function(dispatch) {
-        this._setInputValue('');
-        this._updateAndDispatch('', dispatch);
-        this.$.selector.select(-1);
+        this._setValue(null, null, dispatch);
       },
       attached: function() {
         this.$.dropdown.positionTarget = null;
@@ -537,10 +552,6 @@ Material Design Dropdown/Typeahead/Combobox control
       },
       detached: function() {
         window.removeEventListener('resize:end', this._boundResizeHandler, false);
-      },
-      ready: function() {
-        this.async(function() { this._applyInitialValue(); });
-        this._open = false;
       }
     });
   })();

--- a/radium-combo.html
+++ b/radium-combo.html
@@ -77,15 +77,15 @@ Material Design Dropdown/Typeahead/Combobox control
     </paper-input-container>
     <iron-dropdown id="dropdown" on-iron-overlay-closed="_dropdownClosed">
       <div class="dropdown-content">
+        <template is="dom-if" if="[[_checkShowNoMatches(noMatchesLabel, type, _filteredOptions)]]">
+          <paper-item value="">
+            <span>[[noMatchesLabel]]</span>
+          </paper-item>
+        </template>
         <iron-selector id="selector" attrForSelected="value">
           <template is="dom-if" if="[[_checkShowEmpty(_showEmpty, type)]]">
             <paper-item on-down="_selectItem" on-click="_hideDropdown" value="">
               <span>[[emptyOptionLabel]]</span>
-            </paper-item>
-          </template>
-          <template is="dom-if" if="[[_checkShowNoMatches(noMatchesLabel, type, _filteredOptions)]]">
-            <paper-item value="">
-              <span>[[noMatchesLabel]]</span>
             </paper-item>
           </template>
           <template is="dom-repeat" items="[[_filteredOptions]]">

--- a/radium-combo.html
+++ b/radium-combo.html
@@ -75,7 +75,7 @@ Material Design Dropdown/Typeahead/Combobox control
       <iron-icon id="clear-icon" icon="clear" hidden$="[[!_showClearIcon(showClearButton, _inputValue)]]" on-tap="_clearTapped"></iron-icon>
       <iron-icon id="dropdown-icon" icon="[[_dropdownIcon()]]"></iron-icon>
     </paper-input-container>
-    <iron-dropdown id="dropdown" on-iron-overlay-closed="_dropdownClosed">
+    <iron-dropdown id="dropdown" on-iron-overlay-opened="_dropdownOpened" on-iron-overlay-closed="_dropdownClosed">
       <div class="dropdown-content">
         <template is="dom-if" if="[[_checkShowNoMatches(noMatchesLabel, type, _filteredOptions)]]">
           <paper-item value="">
@@ -378,6 +378,14 @@ Material Design Dropdown/Typeahead/Combobox control
           this._open = false;
           document.removeEventListener('click', this._boundOnCaptureClick, true);
           this.$.dropdown.close();
+        }
+      },
+      _dropdownOpened: function() {
+        // Conditional workaround to eliminate menu overlap introduced only by newer versions of iron-dropdown.
+        var inputRect = this.$['input-container'].getBoundingClientRect();
+        var dropdownRect = this.$.dropdown.getBoundingClientRect();
+        if (inputRect.top === dropdownRect.top) {
+          this.$.dropdown.verticalOffset = inputRect.height;
         }
       },
       _dropdownClosed: function() {

--- a/radium-combo.html
+++ b/radium-combo.html
@@ -476,13 +476,20 @@ Material Design Dropdown/Typeahead/Combobox control
         var option = this._filteredOptions[(this._showEmpty === true) ? idx - 1 : idx];
         this.$.input.value = (option) ? option.__label : '';
 
+        var dropdown = this.$.selector.parentNode;
+
         var itemHeight = 49;
-        var numVisible = Math.floor(this.$.selector.parentNode.offsetHeight / itemHeight);
+        var numVisible = Math.floor(dropdown.offsetHeight / itemHeight);
+        var startVisibleIdx = Math.floor(dropdown.scrollTop / itemHeight);
         if (isUp) {
-          this.$.selector.parentNode.scrollTop = (idx < this._filteredOptions.length - numVisible) ? idx * itemHeight :
-                                        ((this._filteredOptions.length - 1) * itemHeight);
-        } else {
-          this.$.selector.parentNode.scrollTop = (idx >= numVisible) ? idx * itemHeight : 0;
+          if (idx < startVisibleIdx) {
+            dropdown.scrollTop = idx * itemHeight;
+          }
+        }
+        else {
+          if (idx >= startVisibleIdx + numVisible) {
+            dropdown.scrollTop = (idx - (numVisible - 1)) * itemHeight;
+          }
         }
       },
       _findLabelMatch: function(lbl) {

--- a/radium-combo.html
+++ b/radium-combo.html
@@ -21,6 +21,15 @@ Material Design Dropdown/Typeahead/Combobox control
     :host([type='combobox']) #input {
       cursor: text;
     }
+    label, #input {
+      padding-right: 24px;
+      box-sizing: border-box;
+    }
+    #input {
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
     #dropdown {
       margin-top: 56px;
       background-color: #FFFFFF;

--- a/radium-combo.html
+++ b/radium-combo.html
@@ -365,7 +365,8 @@ Material Design Dropdown/Typeahead/Combobox control
           this.$.dropdown.style.width = this.$['input-container'].offsetWidth + 'px';
           this.$.dropdown.positionTarget = this;
           this.$.dropdown.open();
-          if (this.$.input.value === this.value.__label && this.value.__value !== undefined) {
+          var isListItemSelected = this.value.__label !== undefined && this.value.__value !== undefined;
+          if (this.$.input.value === this.value.__label && isListItemSelected) {
             this._filterOptions('');
           }
           // Select the dropdown item based on the current value.

--- a/radium-combo.html
+++ b/radium-combo.html
@@ -52,7 +52,7 @@ Material Design Dropdown/Typeahead/Combobox control
     <paper-input-container id="input-container" on-click="_dropdownAction" disabled$="[[disabled]]" tabindex="0"
       no-label-float="[[noLabelFloat]]" on-keydown="_containerKeyHandler">
       <label>[[label]]</label>
-      <input id="input" is="iron-input" type="text" on-input="_inputValueChanged" on-blur="_onInputBlur"
+      <input id="input" is="iron-input" type="text" autocomplete="off" on-input="_inputValueChanged" on-blur="_onInputBlur"
         on-keydown="_keyHandler" disabled class="paper-input-input"></input>
       <iron-icon id="dropdown-icon" icon="[[_dropdownIcon()]]"></iron-icon>
     </paper-input-container>

--- a/radium-combo.html
+++ b/radium-combo.html
@@ -38,6 +38,14 @@ Material Design Dropdown/Typeahead/Combobox control
     :host([no-label-float]) #dropdown {
       margin-top: 36px;
     }
+    #clear-icon {
+      position: absolute;
+      right: 24px;
+      cursor: pointer;
+      width: 20px;
+      height: 20px;
+      padding: 2px;
+    }
     #dropdown-icon {
       position: absolute;
       right: 0;
@@ -58,11 +66,12 @@ Material Design Dropdown/Typeahead/Combobox control
     }
   </style>
   <template>
-    <paper-input-container id="input-container" on-click="_dropdownAction" disabled$="[[disabled]]" tabindex="0"
+    <paper-input-container id="input-container" on-tap="_dropdownAction" disabled$="[[disabled]]" tabindex="0"
       no-label-float="[[noLabelFloat]]" on-keydown="_containerKeyHandler">
       <label>[[label]]</label>
       <input id="input" is="iron-input" type="text" autocomplete="off" on-input="_inputValueChanged" on-blur="_onInputBlur"
         on-keydown="_keyHandler" disabled class="paper-input-input"></input>
+      <iron-icon id="clear-icon" icon="clear" hidden$="[[!_showClearIcon(showClearButton, _inputValue)]]" on-tap="_clearTapped"></iron-icon>
       <iron-icon id="dropdown-icon" icon="[[_dropdownIcon()]]"></iron-icon>
     </paper-input-container>
     <iron-dropdown id="dropdown" on-iron-overlay-closed="_dropdownClosed">
@@ -71,6 +80,11 @@ Material Design Dropdown/Typeahead/Combobox control
           <template is="dom-if" if="[[_checkShowEmpty(_showEmpty, type)]]">
             <paper-item on-down="_selectItem" on-click="_hideDropdown" value="">
               <span>[[emptyOptionLabel]]</span>
+            </paper-item>
+          </template>
+          <template is="dom-if" if="[[_checkShowNoMatches(noMatchesLabel, type, _filteredOptions)]]">
+            <paper-item value="">
+              <span>[[noMatchesLabel]]</span>
             </paper-item>
           </template>
           <template is="dom-repeat" items="[[_filteredOptions]]">
@@ -157,6 +171,13 @@ Material Design Dropdown/Typeahead/Combobox control
           type: String
         },
         /**
+         * Placeholder text if no matches (for typeahead).
+         */
+        noMatchesLabel: {
+          type: String,
+          value: 'No matches'
+        },
+        /**
          * The type of selection control
          * Choices are:
          *    dropdown
@@ -177,9 +198,21 @@ Material Design Dropdown/Typeahead/Combobox control
           value: 'true',
           observer: '_emptyChanged'
         },
+        /**
+         * Whether or not to include a clear button in the input, allowing the
+         * user to unselect
+         */
+        showClearButton: {
+          type: Boolean,
+          value: false
+        },
         _showEmpty: {
           type: Boolean,
           value: true
+        },
+        _inputValue: {
+          type: String,
+          value: ''
         },
         _optionsInternal: {
           type: Array,
@@ -279,8 +312,14 @@ Material Design Dropdown/Typeahead/Combobox control
       _isDropdown: function() {
         return (this.type.toLowerCase() !== 'combobox' && this.type.toLowerCase() !== 'typeahead');
       },
+      _showClearIcon: function(showClearButton, inputValue) {
+        return showClearButton && inputValue && inputValue.length > 0;
+      },
       _checkShowEmpty: function(e, t) {
         return (e === true && this._isDropdown);
+      },
+      _checkShowNoMatches: function(noMatchesLabel, type, options) {
+        return (noMatchesLabel && noMatchesLabel.length > 0 && type.toLowerCase() === 'typeahead' && options.length === 0);
       },
       _dropdownIcon: function() {
         if (this._open) {
@@ -332,11 +371,17 @@ Material Design Dropdown/Typeahead/Combobox control
       _dropdownClosed: function() {
         this._open = false;
       },
+      _clearTapped: function (e) {
+        e.stopImmediatePropagation();
+
+        this.clearSelection(true);
+      },
       _handleFloatingLabel: function(value) {
         this.$['input-container']._inputHasContent = !(!value || value === null || value === '');
       },
       _inputValueChanged: function(e) {
         var input = e.target.value;
+        this._inputValue = input;
         this._handleFloatingLabel(input);
         this._filterOptions(input);
         // Select the dropdown item based on the current input.
@@ -490,6 +535,7 @@ Material Design Dropdown/Typeahead/Combobox control
       },
       _setInputValue: function(v) {
         this._handleFloatingLabel(v);
+        this._inputValue = v;
         this.$.input.value = v;
       },
       _setSelectorSelected: function(idx) {

--- a/radium-combo.html
+++ b/radium-combo.html
@@ -415,7 +415,7 @@ Material Design Dropdown/Typeahead/Combobox control
         this.setValue(item.value, true);
       },
       _updateAndDispatch: function(value, dispatch) {
-        if (this.value.__label !== value.__label && this.value.__value !== value.__value) {
+        if (!(this.value.__label === value.__label && this.value.__value === value.__value)) {
           this.value = value;
           if (dispatch === true) {
             this.fire('option-change', {label:value.__label, value:value.__value});

--- a/radium-combo.html
+++ b/radium-combo.html
@@ -365,7 +365,9 @@ Material Design Dropdown/Typeahead/Combobox control
           this.$.dropdown.style.width = this.$['input-container'].offsetWidth + 'px';
           this.$.dropdown.positionTarget = this;
           this.$.dropdown.open();
-          this._filterOptions('');
+          if (this.$.input.value === this.value.__label && this.value.__value !== undefined) {
+            this._filterOptions('');
+          }
           // Select the dropdown item based on the current value.
           this._setSelectorSelected(this._findFilteredOptionValueIndex(this.value.__value));
         }

--- a/radium-combo.html
+++ b/radium-combo.html
@@ -144,8 +144,8 @@ Material Design Dropdown/Typeahead/Combobox control
          * Currently selected value
          */
         value: {
-          type: String,
-          value: '',
+          type: Object,
+          value: function() { return {}; },
           notify: true,
           observer: '_valueChanged'
         },
@@ -415,7 +415,7 @@ Material Design Dropdown/Typeahead/Combobox control
         this.setValue(item.value, true);
       },
       _updateAndDispatch: function(value, dispatch) {
-        if (this.value !== value) {
+        if (this.value.value !== value.__value) {
           this.value = value;
           if (dispatch === true) {
             this.fire('option-change', {label:value.__label, value:value.__value});

--- a/radium-combo.html
+++ b/radium-combo.html
@@ -66,8 +66,9 @@ Material Design Dropdown/Typeahead/Combobox control
     }
   </style>
   <template>
-    <paper-input-container id="input-container" on-tap="_dropdownAction" disabled$="[[disabled]]" tabindex="0"
-      no-label-float="[[noLabelFloat]]" on-keydown="_containerKeyHandler">
+    <paper-input-container id="input-container" disabled$="[[disabled]]" tabindex="0"
+      always-float-label="[[alwaysFloatLabel]]"  no-label-float="[[noLabelFloat]]"
+      on-keydown="_containerKeyHandler" on-tap="_dropdownAction" >
       <label>[[label]]</label>
       <input id="input" is="iron-input" type="text" autocomplete="off" on-input="_inputValueChanged" on-blur="_onInputBlur"
         on-keydown="_keyHandler" disabled class="paper-input-input"></input>
@@ -112,6 +113,13 @@ Material Design Dropdown/Typeahead/Combobox control
         Polymer.IronSelectableBehavior
       ],
       properties: {
+        /**
+         * Always float the floating label.
+         */
+        alwaysFloatLabel: {
+          type: Boolean,
+          value: false
+        },
         /**
          * Optional floating label for the input control
          */


### PR DESCRIPTION
#### General fixes and enhancements:
- Added pass-through of `alwaysFloatLabel` property to input container.
- Tweaked CSS to ensure the input text doesn't overflow the dropdown arrow.
- Added optional clear button.
- Tweaked logic for scrolling the dropdown during keyboard navigation.
#### Typeahead (and combobox) mode fixes and enhancements:
- Disabled browser autocomplete (otherwise the native browser autocomplete overlaps this component's dropdown).
- Fixed a bug where clicking on a dropdown option was ignored if the input had focus.
  - The `blur` handler was firing (clearing the result) before the `tap` handler.
  - Changed this to use a `down` handler, since that has higher priority.
  - Replaced component-level `tap` handling via `updateSelected()` with item level `tap` handling via `_selectItem()`.
- Consolidated common logic in `setValue()`, `setValueFromLabel()` and `clearSelection()` to avoid code duplication and ensure consistent UI state changes for all combo types.
- Added `_findFilteredOptionLabelIndex` and `_findFilteredOptionValueIndex` to allow the correct match to be highlighted (and items to be unhighlighted) while typing in the typeahead.
- Changed selector selected state to be lazily initialized/updated when the dropdown is opened and when the input is changed.
- Added "No matches" item (with configurable text) for typeaheads.
- Tweaked keyboard navigation - only commits value on `Enter` or when dropdown is closed.
  - Previously silently updated `value` during interaction.
  - Now updates label and applies to `value` (and notifies via event) when interaction is complete.
  - This helped resolve typeahead issues with sending duplicate notifications (or failing to send them).

![radium-combo-enhancements-optimized](https://cloud.githubusercontent.com/assets/140385/14189865/9ac40c8a-f75d-11e5-84fb-4de7890e0df2.gif)
