### PR TITLE
Fix for mobile safari text styling - input appears disabled.

### DIFF
--- a/radium-combo.html
+++ b/radium-combo.html
@@ -30,6 +30,10 @@ Material Design Dropdown/Typeahead/Combobox control
       overflow: hidden;
       text-overflow: ellipsis;
     }
+    #input[disabled] {
+      opacity: 1.0;
+      -webkit-text-fill-color: #212121;
+    }
     #dropdown {
       margin-top: 56px;
       background-color: #FFFFFF;


### PR DESCRIPTION
Mobile Safari has additional default browser styles for input fields that need to be overridden to obtain a consistent appearance for the input text (relative to other browsers).

**Before:**
![before](https://cloud.githubusercontent.com/assets/140385/15183696/363281ac-1760-11e6-8414-d474e96f0bc8.png)

**After:**
![after](https://cloud.githubusercontent.com/assets/140385/15183698/3999acc6-1760-11e6-93f5-de63138a753e.png)
