### PR TITLE
Switch from down + click events to tap event for iron-dropdown items listeners.

### DIFF
--- a/radium-combo.html
+++ b/radium-combo.html
@@ -96,7 +96,7 @@ Material Design Dropdown/Typeahead/Combobox control
         </template>
         <iron-selector id="selector" attrForSelected="value">
           <template is="dom-if" if="[[_checkShowEmpty(_showEmpty, type)]]">
-            <paper-item on-down="_selectItem" on-click="_hideDropdown" value="">
+            <paper-item on-tap="_selectItem" value="">
               <span>[[emptyOptionLabel]]</span>
             </paper-item>
           </template>
@@ -436,8 +436,10 @@ Material Design Dropdown/Typeahead/Combobox control
         }
       },
       _selectItem: function(e) {
+        e.stopPropagation();
         var item = e.currentTarget;
         this.setValue(item.value, true);
+        this._hideDropdown();
       },
       _updateAndDispatch: function(value, dispatch) {
         if (!(this.value.__label === value.__label && this.value.__value === value.__value)) {


### PR DESCRIPTION
Otherwise touch devices (phones and tablets) are unable to scroll the dropdown. The initial `touchdown` will immediately select the item, making `touchmove` scrolling impossible. Polymer will synthesize a tap event for mouse environments.

Also stopped event propagation so the "tap" doesn't register through to other controls underneath the dropdown.  For example, prior to this fix, tapping an item in a `radium-combo` used in a `radium-filter-panel` would not only select the item but would also incorrectly trigger collapse or focus on the field that appeared under it.
