### PR TITLE
Fixes for mobile and interaction in typeahead mode.

### DIFF
--- a/radium-combo.html
+++ b/radium-combo.html
@@ -82,7 +82,8 @@ Material Design Dropdown/Typeahead/Combobox control
       always-float-label="[[alwaysFloatLabel]]"  no-label-float="[[noLabelFloat]]"
       on-keydown="_containerKeyHandler" on-tap="_dropdownAction" title$="[[_inputValue]]">
       <label>[[label]]</label>
-      <input id="input" is="iron-input" type="text" autocomplete="off" on-input="_inputValueChanged" on-blur="_onInputBlur"
+      <input id="input" is="iron-input" type="text" autocomplete="off" on-input="_inputValueChanged"
+        on-focus="_onInputFocus" on-blur="_onInputBlur"
         on-keydown="_keyHandler" disabled class="paper-input-input"></input>
       <iron-icon id="clear-icon" icon="clear" hidden$="[[!_showClearIcon(showClearButton, _inputValue)]]" on-tap="_clearTapped"></iron-icon>
       <iron-icon id="dropdown-icon" icon="[[_dropdownIcon()]]"></iron-icon>
@@ -96,12 +97,12 @@ Material Design Dropdown/Typeahead/Combobox control
         </template>
         <iron-selector id="selector" attrForSelected="value">
           <template is="dom-if" if="[[_checkShowEmpty(_showEmpty, type)]]">
-            <paper-item on-tap="_selectItem" value="">
+            <paper-item on-down="_onItemDown" on-tap="_selectItem" value="">
               <span>[[emptyOptionLabel]]</span>
             </paper-item>
           </template>
           <template is="dom-repeat" items="[[_filteredOptions]]">
-            <paper-item on-down="_selectItem" on-click="_hideDropdown" value="[[item.__value]]">
+            <paper-item on-down="_onItemDown" on-tap="_selectItem" value="[[item.__value]]">
               <span title$="[[item.__label]]">[[item.__label]]</span>
             </paper-item>
           </template>
@@ -246,11 +247,15 @@ Material Design Dropdown/Typeahead/Combobox control
           type: Boolean,
           value: false
         },
-        _boundOnCaptureClick: {
+        _boundOnCaptureTap: {
           type: Function,
           value: function() {
-            return this._onCaptureClick.bind(this);
+            return this._onCaptureTap.bind(this);
           }
+        },
+        _ignoreBlur: {
+          type: Boolean,
+          value: false
         }
       },
       observers: [
@@ -357,7 +362,7 @@ Material Design Dropdown/Typeahead/Combobox control
           this._openDropdown();
         }
       },
-      _onCaptureClick: function(e) {
+      _onCaptureTap: function(e) {
         var node = e.target;
         while (node != null) {
           if (node == this) {
@@ -366,6 +371,7 @@ Material Design Dropdown/Typeahead/Combobox control
           node = node.parentNode;
         }
         if (node === null) {
+          e.stopPropagation();
           this.async(function() {
             this._applyValueFromInput();
             this._hideDropdown();
@@ -375,7 +381,7 @@ Material Design Dropdown/Typeahead/Combobox control
       _openDropdown: function() {
         if (this._open === false) {
           this._open = true;
-          document.addEventListener('click', this._boundOnCaptureClick, true);
+          document.addEventListener('tap', this._boundOnCaptureTap, true);
           this.$.dropdown.style.width = this.$['input-container'].offsetWidth + 'px';
           this.$.dropdown.positionTarget = this;
           this.$.dropdown.open();
@@ -390,7 +396,7 @@ Material Design Dropdown/Typeahead/Combobox control
       _hideDropdown: function() {
         if (this._open === true) {
           this._open = false;
-          document.removeEventListener('click', this._boundOnCaptureClick, true);
+          document.removeEventListener('tap', this._boundOnCaptureTap, true);
           this.$.dropdown.close();
         }
       },
@@ -449,8 +455,18 @@ Material Design Dropdown/Typeahead/Combobox control
           }
         }
       },
+      _onItemDown: function(e) {
+        e.stopPropagation();
+        // NOTE: Input blur event fires after "down" but before "tap" - don't perform blur logic when an item is tapped.
+        this._ignoreBlur = true;
+      },
+      _onInputFocus: function() {
+        this._ignoreBlur = false;
+      },
       _onInputBlur: function() {
-        this._applyValueFromInput();
+        if (!this._ignoreBlur) {
+          this._applyValueFromInput();
+        }
       },
       _containerKeyHandler: function(e) {
         if (document.activeElement === this.$['input-container']) {

--- a/radium-combo.html
+++ b/radium-combo.html
@@ -36,6 +36,8 @@ Material Design Dropdown/Typeahead/Combobox control
     #input[disabled] {
       opacity: 1.0;
       -webkit-text-fill-color: #212121;
+      -webkit-user-select: none;
+      user-select: none;
     }
     #dropdown {
       margin-top: 56px;
@@ -80,15 +82,15 @@ Material Design Dropdown/Typeahead/Combobox control
   <template>
     <paper-input-container id="input-container" disabled$="[[disabled]]" tabindex="0"
       always-float-label="[[alwaysFloatLabel]]"  no-label-float="[[noLabelFloat]]"
-      on-keydown="_containerKeyHandler" on-tap="_dropdownAction" title$="[[_inputValue]]">
+      on-keydown="_containerKeyHandler" on-down="_dropdownAction" title$="[[_inputValue]]">
       <label>[[label]]</label>
       <input id="input" is="iron-input" type="text" autocomplete="off" on-input="_inputValueChanged"
         on-focus="_onInputFocus" on-blur="_onInputBlur"
         on-keydown="_keyHandler" disabled class="paper-input-input"></input>
       <iron-icon id="clear-icon" icon="clear" hidden$="[[!_showClearIcon(showClearButton, _inputValue)]]" on-tap="_clearTapped"></iron-icon>
-      <iron-icon id="dropdown-icon" icon="[[_dropdownIcon()]]"></iron-icon>
+      <iron-icon id="dropdown-icon" icon="[[_dropdownIcon(_open)]]"></iron-icon>
     </paper-input-container>
-    <iron-dropdown id="dropdown" on-iron-overlay-opened="_dropdownOpened" on-iron-overlay-closed="_dropdownClosed">
+    <iron-dropdown id="dropdown" no-cancel-on-outside-click no-overlap on-iron-overlay-opened="_dropdownOpened" on-iron-overlay-closed="_dropdownClosed">
       <div class="dropdown-content">
         <template is="dom-if" if="[[_checkShowNoMatches(noMatchesLabel, type, _filteredOptions)]]">
           <paper-item value="">
@@ -97,12 +99,12 @@ Material Design Dropdown/Typeahead/Combobox control
         </template>
         <iron-selector id="selector" attrForSelected="value">
           <template is="dom-if" if="[[_checkShowEmpty(_showEmpty, type)]]">
-            <paper-item on-down="_onItemDown" on-tap="_selectItem" value="">
+            <paper-item on-down="_onItemDown" on-touchend="_onItemTouchEnd" on-tap="_selectItem" value="">
               <span>[[emptyOptionLabel]]</span>
             </paper-item>
           </template>
           <template is="dom-repeat" items="[[_filteredOptions]]">
-            <paper-item on-down="_onItemDown" on-tap="_selectItem" value="[[item.__value]]">
+            <paper-item on-down="_onItemDown" on-touchend="_onItemTouchEnd" on-tap="_selectItem" value="[[item.__value]]">
               <span title$="[[item.__label]]">[[item.__label]]</span>
             </paper-item>
           </template>
@@ -247,12 +249,6 @@ Material Design Dropdown/Typeahead/Combobox control
           type: Boolean,
           value: false
         },
-        _boundOnCaptureTap: {
-          type: Function,
-          value: function() {
-            return this._onCaptureTap.bind(this);
-          }
-        },
         _ignoreBlur: {
           type: Boolean,
           value: false
@@ -261,6 +257,7 @@ Material Design Dropdown/Typeahead/Combobox control
       observers: [
         '_optionsSplicesChanged(options.splices)'
       ],
+      _boundCaptureTap: null,
       _boundResizeHandler: null,
       _valueChanged: function(v) {
         if (!this._isObject(v)) {
@@ -348,8 +345,8 @@ Material Design Dropdown/Typeahead/Combobox control
       _checkShowNoMatches: function(noMatchesLabel, type, options) {
         return (noMatchesLabel && noMatchesLabel.length > 0 && type.toLowerCase() === 'typeahead' && options.length === 0);
       },
-      _dropdownIcon: function() {
-        if (this._open) {
+      _dropdownIcon: function(open) {
+        if (open) {
           return 'arrow-drop-up';
         } else {
           return 'arrow-drop-down';
@@ -363,25 +360,13 @@ Material Design Dropdown/Typeahead/Combobox control
         }
       },
       _onCaptureTap: function(e) {
-        var node = e.target;
-        while (node != null) {
-          if (node == this) {
-            break;
-          }
-          node = node.parentNode;
-        }
-        if (node === null) {
-          e.stopPropagation();
-          this.async(function() {
-            this._applyValueFromInput();
-            this._hideDropdown();
-          }, 10);
+        if (!this.contains(e.target)) {
+          this.$.input.blur();
+          this._hideDropdown();
         }
       },
       _openDropdown: function() {
         if (this._open === false) {
-          this._open = true;
-          document.addEventListener('tap', this._boundOnCaptureTap, true);
           this.$.dropdown.style.width = this.$['input-container'].offsetWidth + 'px';
           this.$.dropdown.positionTarget = this;
           this.$.dropdown.open();
@@ -395,18 +380,11 @@ Material Design Dropdown/Typeahead/Combobox control
       },
       _hideDropdown: function() {
         if (this._open === true) {
-          this._open = false;
-          document.removeEventListener('tap', this._boundOnCaptureTap, true);
           this.$.dropdown.close();
         }
       },
       _dropdownOpened: function() {
-        // Conditional workaround to eliminate menu overlap introduced only by newer versions of iron-dropdown.
-        var inputRect = this.$['input-container'].getBoundingClientRect();
-        var dropdownRect = this.$.dropdown.getBoundingClientRect();
-        if (inputRect.top === dropdownRect.top) {
-          this.$.dropdown.verticalOffset = inputRect.height;
-        }
+        this._open = true;
       },
       _dropdownClosed: function() {
         this._open = false;
@@ -442,7 +420,6 @@ Material Design Dropdown/Typeahead/Combobox control
         }
       },
       _selectItem: function(e) {
-        e.stopPropagation();
         var item = e.currentTarget;
         this.setValue(item.value, true);
         this._hideDropdown();
@@ -456,17 +433,23 @@ Material Design Dropdown/Typeahead/Combobox control
         }
       },
       _onItemDown: function(e) {
-        e.stopPropagation();
         // NOTE: Input blur event fires after "down" but before "tap" - don't perform blur logic when an item is tapped.
         this._ignoreBlur = true;
       },
+      _onItemTouchEnd: function(e) {
+        // NOTE: This prevents synthesized "click" events that will bleed through and click items under the dropdown.
+        e.preventDefault();
+      },
       _onInputFocus: function() {
         this._ignoreBlur = false;
+        this._openDropdown();
       },
       _onInputBlur: function() {
         if (!this._ignoreBlur) {
           this._applyValueFromInput();
+          this._hideDropdown();
         }
+        this._ignoreBlur = false;
       },
       _containerKeyHandler: function(e) {
         if (document.activeElement === this.$['input-container']) {
@@ -656,11 +639,14 @@ Material Design Dropdown/Typeahead/Combobox control
       },
       attached: function() {
         this.$.dropdown.positionTarget = null;
+        this._boundOnCaptureTap = this._onCaptureTap.bind(this);
         this._boundResizeHandler = this._hideDropdown.bind(this);
+        document.addEventListener('tap', this._boundOnCaptureTap, true);
         window.addEventListener('resize:end', this._boundResizeHandler, false);
       },
       detached: function() {
         window.removeEventListener('resize:end', this._boundResizeHandler, false);
+        document.removeEventListener('tap', this._boundOnCaptureTap, true);
       }
     });
   })();

--- a/radium-combo.html
+++ b/radium-combo.html
@@ -620,6 +620,7 @@ Material Design Dropdown/Typeahead/Combobox control
           }
           else {
             this._setInputValue('');
+            this._filterOptions('');
             this._updateAndDispatch({}, dispatch);
           }
         }


### PR DESCRIPTION
- My previous pull request broke interaction when in the `typeahead` mode.
  - The "blur" event fires before the "tap" event, so tap selections within the dropdown were being clobbered by the `_onInputBlur()` handler.
  - (Somehow I had blocked out the painful memories of running into this before and working around it with that separate `on-down` handler.)
  - Added an `_ignoreBlur` Boolean to track whether the blur should be ignored.
  - Added `_onInputFocus()` and `_onItemDown()` handlers to coordinate the state of this new flag.
  - (It would have been nice to have been able to simply use the `FocusEvent::relatedTarget` in `_onInputBlur()` to filter out blurs triggered by focus change to the element's `iron-dropdown` items - alas, that property is experimental and not available in Firefox.)
- I also missed making the "click" -> "tap" change for the second template in the `iron-selector` element.
  - I have now applied the same changes to the second template as the first.
- Switched out the "click" event type for "tap" in `_boundOnCaptureClick()`, `_onCaptureClick()`, etc. to ensure these also fire on mobile devices and updates the internal bookkeeping properties.
