### PR TITLE
v0.6.0 tagged release

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "radium-combo",
-  "version": "0.0.1",
+  "version": "0.6.0",
   "description": "Material Design Dropdown/Typeahead/Combobox control",
   "authors": [
     "jason gardner <jason.gardner.lv@gmail.com>"


### PR DESCRIPTION
Could we tag the current code as a v0.6.0 release?  This way we can have our current production release codebase safely point to the current snapshot now and in the future.

I'll be following up after this with another PR to update the dependencies (as you did for radium-datagrid) to Polymer 1.7, etc.