### PR TITLE
Updated to Polymer 1.7

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "radium-combo",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Material Design Dropdown/Typeahead/Combobox control",
   "authors": [
     "jason gardner <jason.gardner.lv@gmail.com>"
@@ -24,18 +24,13 @@
   "homepage": "https://github.com/jasongardnerlv/radium-combo",
   "ignore": [],
   "dependencies": {
-    "polymer": "Polymer/polymer#^1.2.3",
-    "iron-dropdown": "PolymerElements/iron-dropdown#^1.0.6",
-    "iron-icon": "PolymerElements/iron-icon#^1.0.7",
-    "iron-icons": "PolymerElements/iron-icons#^1.0.4",
-    "iron-selector": "PolymerElements/iron-selector#^1.0.8",
-    "paper-input": "PolymerElements/paper-input#^1.1.2",
-    "paper-item": "PolymerElements/paper-item#^1.0.5"
+    "polymer": "Polymer/polymer#1.7.0",
+    "iron-dropdown": "PolymerElements/iron-dropdown#1.5.4",
+    "iron-icon": "PolymerElements/iron-icon#1.0.12",
+    "iron-icons": "PolymerElements/iron-icons#1.2.0",
+    "iron-selector": "PolymerElements/iron-selector#1.5.2",
+    "paper-input": "PolymerElements/paper-input#1.1.22",
+    "paper-item": "PolymerElements/paper-item#1.2.1"
   },
-  "devDependencies": {
-    "paper-toggle-button": "PolymerElements/paper-toggle-button#^1.0.11",
-    "webcomponentsjs": "webcomponents/webcomponentsjs#^0.7.0",
-    "web-component-tester": "Polymer/web-component-tester#^3.3.0",
-    "test-fixture": "PolymerElements/test-fixture#^1.0.0"
-  }
+  "devDependencies": {}
 }

--- a/radium-combo.html
+++ b/radium-combo.html
@@ -420,6 +420,8 @@ Material Design Dropdown/Typeahead/Combobox control
         }
       },
       _selectItem: function(e) {
+        e.stopImmediatePropagation();
+        
         var item = e.currentTarget;
         this.setValue(item.value, true);
         this._hideDropdown();

--- a/radium-combo.html
+++ b/radium-combo.html
@@ -390,7 +390,7 @@ Material Design Dropdown/Typeahead/Combobox control
         this._open = false;
       },
       _clearTapped: function (e) {
-        e.stopImmediatePropagation();
+        e.stopPropagation();
 
         this.clearSelection(true);
       },
@@ -420,7 +420,7 @@ Material Design Dropdown/Typeahead/Combobox control
         }
       },
       _selectItem: function(e) {
-        e.stopImmediatePropagation();
+        e.stopPropagation();
         
         var item = e.currentTarget;
         this.setValue(item.value, true);

--- a/radium-combo.html
+++ b/radium-combo.html
@@ -90,7 +90,7 @@ Material Design Dropdown/Typeahead/Combobox control
       <iron-icon id="clear-icon" icon="clear" hidden$="[[!_showClearIcon(showClearButton, _inputValue)]]" on-tap="_clearTapped"></iron-icon>
       <iron-icon id="dropdown-icon" icon="[[_dropdownIcon(_open)]]"></iron-icon>
     </paper-input-container>
-    <iron-dropdown id="dropdown" no-cancel-on-outside-click no-overlap on-iron-overlay-opened="_dropdownOpened" on-iron-overlay-closed="_dropdownClosed">
+    <iron-dropdown id="dropdown" no-cancel-on-outside-click on-iron-overlay-opened="_dropdownOpened" on-iron-overlay-closed="_dropdownClosed">
       <div class="dropdown-content">
         <template is="dom-if" if="[[_checkShowNoMatches(noMatchesLabel, type, _filteredOptions)]]">
           <paper-item value="">


### PR DESCRIPTION
* Bumped version to 0.7.0.
* Updated all dependencies (included Polymer) to known-good versions (similar to what was done recently for `radium-datagrid`).
* Added missing `e. stopImmediatePropagation()` calls to tap handlers.
    * Addresses issues caused when events bubble up to `<paper-drawer-panel>`, especially for elements that handlers in these components removed.
    * (`<paper-drawer-panel>` was throwing an runtime error: "Failed to execute 'contains' on 'Node': parameter 1 is not of type 'Node'." for these events.)
* Removed `no-overlap` attribute from `iron-dropdown`.
    * The layout logic for this mode conflicted with CSS styles for `margin-top` - resulting in dropdown positioning issues relative to the input field.