### PR TITLE
Revised to apply vertical-align=auto and no-overlap to embedded iron-dropdown

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "radium-combo",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Material Design Dropdown/Typeahead/Combobox control",
   "authors": [
     "jason gardner <jason.gardner.lv@gmail.com>"

--- a/radium-combo.html
+++ b/radium-combo.html
@@ -40,12 +40,8 @@ Material Design Dropdown/Typeahead/Combobox control
       user-select: none;
     }
     #dropdown {
-      margin-top: 56px;
       background-color: #FFFFFF;
       box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.14), 0 1px 5px 0 rgba(0, 0, 0, 0.12), 0 3px 1px -2px rgba(0, 0, 0, 0.2);
-    }
-    :host([no-label-float]) #dropdown {
-      margin-top: 36px;
     }
     #clear-icon {
       position: absolute;
@@ -90,7 +86,7 @@ Material Design Dropdown/Typeahead/Combobox control
       <iron-icon id="clear-icon" icon="clear" hidden$="[[!_showClearIcon(showClearButton, _inputValue)]]" on-tap="_clearTapped"></iron-icon>
       <iron-icon id="dropdown-icon" icon="[[_dropdownIcon(_open)]]"></iron-icon>
     </paper-input-container>
-    <iron-dropdown id="dropdown" no-cancel-on-outside-click on-iron-overlay-opened="_dropdownOpened" on-iron-overlay-closed="_dropdownClosed">
+    <iron-dropdown id="dropdown" vertical-align="auto" no-overlap no-cancel-on-outside-click on-iron-overlay-opened="_dropdownOpened" on-iron-overlay-closed="_dropdownClosed">
       <div class="dropdown-content">
         <template is="dom-if" if="[[_checkShowNoMatches(noMatchesLabel, type, _filteredOptions)]]">
           <paper-item value="">


### PR DESCRIPTION
This resolves an issue where the dropdown content is clipped, by allowing the dropdown to open “up” rather than “down” when there is not enough available screen space below the input container.