### PR TITLE
Input height tweak for Internet Explorer

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "radium-combo",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Material Design Dropdown/Typeahead/Combobox control",
   "authors": [
     "jason gardner <jason.gardner.lv@gmail.com>"

--- a/radium-combo.html
+++ b/radium-combo.html
@@ -14,6 +14,7 @@ Material Design Dropdown/Typeahead/Combobox control
   <style is="custom-style">
     #input {
       cursor: pointer;
+      height: 24px;
     }
     :host([type='typeahead']) #input {
       cursor: text;


### PR DESCRIPTION
* Added explicit `height` for `input` to fix an issue where Internet Explorer defaulted to a smaller height and clipped the input text.